### PR TITLE
Require sudo-enabled Linux on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "7"
 dist: trusty
-sudo: false
+sudo: required
 addons:
   chrome: stable
 git:


### PR DESCRIPTION
I am proposing this change to address recent changes to container-based Linux                                                                                                                                                                  
at Travis.  There are extensive comments available in [this                                                                                                                                                                                    
issue](https://github.com/travis-ci/travis-ci/issues/8836), but the gist is                                                                                                                                                                    
that container-based Linux can no longer support sandboxed Chrome.  Either this                                                                                                                                                                
change or the addition of `--no-sandbox` will suffice.  I'm happy to propose                                                                                                                                                                   
changes to the referencing blog post, too :smiley_cat:.